### PR TITLE
Enable fluidity to work with atomify and other CSS modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fluidity",
   "version": "0.0.1",
   "description": "Worlds lightest-weight fully responsive css framework.",
+  "style": "./css/fluidity.css",
   "repository" : {
     "type" : "git" ,
     "url" : "http://github.com/mrmrs/fluidity.git"


### PR DESCRIPTION
Lots of tools are standardizing on the `"style": "./path/to/style.css"`, this makes fluidity work with that.
