### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-http://fluidity.sexy


### PR DESCRIPTION
The fluidity.sexy domain is down.
This change allows the default GitHub Pages domain to work again,
so that the site will be live at https://mrmrs.github.io/fluidity/.

Addresses #30.